### PR TITLE
Issue filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ program
   .option('--skip-low', 'Skip low issues')
   .option('--skip-medium', 'Skip medium issues')
   .option('--skip-high', 'Skip high issues')
+  .option('--skip, --skip-detectors [detectorID...]', 'Skip specific detectors by id')
   .action((basePath:string, options) => {
     basePath = basePath ||'contracts/';
     basePath = basePath.endsWith('/') ? basePath : `${basePath}/`;
@@ -38,16 +39,19 @@ program
     if(!options.skipMedium) severityToRun.push(IssueTypes.M);
     if(!options.skipHigh) severityToRun.push(IssueTypes.H);
 
+    const skipDetectors = options.skip || [];
+    const skipDetectorsLower = skipDetectors.map(detector => detector.toLowerCase()); // Convert to lowercase to avoid case-sensitive issues
+
     console.log(`basePath: ${basePath}`);
     console.log(`scope: ${options.scope||'----'}`);
     console.log(`github: ${options.github||'----'}`);
     console.log(`out: ${options.out||'report.md'}`);
     console.log(`legacyScope: ${options.legacyscope||'----'}`);
     console.log(`sarif: ${options.sarif||'----'}`);
-    console.log(`severityMinimum: ${options.severityMinimum||'0'}`);
     console.log('Severity to run: ', severityToRun);
+    console.log('Skipping detectors: ', skipDetectorsLower);
 
     console.log('*****************************')
     // ============================== RUN ANALYZER ==============================
-    main(basePath, options.scope, options.github, options.out || 'report.md', severityToRun, options.legacyscope, options.sarif, options.listfiles);
+    main(basePath, options.scope, options.github, options.out || 'report.md', severityToRun, skipDetectorsLower, options.legacyscope, options.sarif, options.listfiles);
   }).parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import main from './main';
 // ================================= PARAMETERS ================================
 
 import { program } from 'commander';
+import { IssueTypes } from './types';
 
 program
   .argument('[basePath]', 'Path were the contracts lies')
@@ -18,23 +19,35 @@ program
   .option('-o, --out <reportPath>', 'Path for Markdown report')
   .option('-l, --listfiles', 'List analyzed files in Markdown Report')
   .option('--legacyscope <scopeFile>', 'Path for legacy scope file')
-  .option('--sarif [string]', 'Generate SARIF report, optionally include path to report. Default is analyzer.sarif', )
+  .option('--sarif [outputPath]', 'Generate SARIF report, optionally include path to report. Default is analyzer.sarif')
+  .option('--skip-info', 'Skip info issues')
+  .option('--skip-gas', 'Skip gas issues')
+  .option('--skip-low', 'Skip low issues')
+  .option('--skip-medium', 'Skip medium issues')
+  .option('--skip-high', 'Skip high issues')
   .action((basePath:string, options) => {
     basePath = basePath ||'contracts/';
     basePath = basePath.endsWith('/') ? basePath : `${basePath}/`;
+
+    const sarif = options.sarif === true ? 'analyzer.sarif' : options.sarif;
+    
+    const severityToRun: IssueTypes[] = [];
+    if(!options.skipInfo) severityToRun.push(IssueTypes.NC);
+    if(!options.skipGas) severityToRun.push(IssueTypes.GAS);
+    if(!options.skipLow) severityToRun.push(IssueTypes.L);
+    if(!options.skipMedium) severityToRun.push(IssueTypes.M);
+    if(!options.skipHigh) severityToRun.push(IssueTypes.H);
+
     console.log(`basePath: ${basePath}`);
     console.log(`scope: ${options.scope||'----'}`);
     console.log(`github: ${options.github||'----'}`);
     console.log(`out: ${options.out||'report.md'}`);
     console.log(`legacyScope: ${options.legacyscope||'----'}`);
     console.log(`sarif: ${options.sarif||'----'}`);
-
-    let sarif;
-    if(options.sarif === undefined) sarif = undefined;
-    else if(options.sarif === true) sarif = 'analyzer.sarif';
-    else sarif = options.sarif;
+    console.log(`severityMinimum: ${options.severityMinimum||'0'}`);
+    console.log('Severity to run: ', severityToRun);
 
     console.log('*****************************')
-    // ============================== GENERATE REPORT ==============================
-    main(basePath, options.scope, options.github, options.out || 'report.md', options.legacyscope, sarif, options.listfiles);
+    // ============================== RUN ANALYZER ==============================
+    main(basePath, options.scope, options.github, options.out || 'report.md', severityToRun, options.legacyscope, options.sarif, options.listfiles);
   }).parse();

--- a/src/issues/GAS/ERC721A.ts
+++ b/src/issues/GAS/ERC721A.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'erc721A',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use ERC721A instead ERC721',

--- a/src/issues/GAS/_msgSender.ts
+++ b/src/issues/GAS/_msgSender.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: '_msgSender',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: "Don't use `_msgSender()` if not supporting EIP-2771",

--- a/src/issues/GAS/addPlusEqual.ts
+++ b/src/issues/GAS/addPlusEqual.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'addPlusEqual',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: '`a = a + b` is more gas effective than `a += b` for state variables (excluding arrays and mappings)',

--- a/src/issues/GAS/addressZero.ts
+++ b/src/issues/GAS/addressZero.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import { Expression, SourceUnit } from 'solidity-ast';
 
 const issue: ASTIssue = {
+  id: 'addressZero',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: 'Use assembly to check for `address(0)`',

--- a/src/issues/GAS/assignUpdateArray.ts
+++ b/src/issues/GAS/assignUpdateArray.ts
@@ -3,6 +3,7 @@ import { findAll } from 'solidity-ast/utils';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'assignUpdateArray',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: '`array[index] += amount` is cheaper than `array[index] = array[index] + amount` (or related variants)',

--- a/src/issues/GAS/boolCompare.ts
+++ b/src/issues/GAS/boolCompare.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'boolCompare',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Comparing to a Boolean constant',

--- a/src/issues/GAS/boolIncursOverhead.ts
+++ b/src/issues/GAS/boolIncursOverhead.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'boolIncursOverhead',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Using bools for storage incurs overhead',

--- a/src/issues/GAS/cacheArrayLength.ts
+++ b/src/issues/GAS/cacheArrayLength.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'cacheArrayLength',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Cache array length outside of loop',

--- a/src/issues/GAS/cacheVariable.ts
+++ b/src/issues/GAS/cacheVariable.ts
@@ -4,6 +4,7 @@ import { getStorageVariable, instanceFromSRC } from '../../utils';
 import { Identifier } from 'solidity-ast';
 
 const issue: ASTIssue = {
+  id: 'cacheVariable',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: 'State variables should be cached in stack variables rather than re-reading them from storage',

--- a/src/issues/GAS/calldataViewFunctions.ts
+++ b/src/issues/GAS/calldataViewFunctions.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'calldataViewFunctions',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: 'Use calldata instead of memory for function arguments that do not get mutated',

--- a/src/issues/GAS/canUseUnchecked.ts
+++ b/src/issues/GAS/canUseUnchecked.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'canUseUnchecked',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'For Operations that will not overflow, you could use unchecked',

--- a/src/issues/GAS/customErrors.ts
+++ b/src/issues/GAS/customErrors.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'customErrors',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use Custom Errors instead of Revert Strings to save Gas',

--- a/src/issues/GAS/delegatecallAddressCheck.ts
+++ b/src/issues/GAS/delegatecallAddressCheck.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'delegatecallAddressCheck',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Avoid contract existence checks by using low level calls',

--- a/src/issues/GAS/dontCacheIfUsedOnce.ts
+++ b/src/issues/GAS/dontCacheIfUsedOnce.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'dontCacheIfUsedOnce',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: 'Stack variable used as a cheaper cache for a state variable is only used once',

--- a/src/issues/GAS/immutableConstructor.ts
+++ b/src/issues/GAS/immutableConstructor.ts
@@ -4,6 +4,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, topLevelFiles, getStorageVariable } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'immutableConstructor',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: 'State variables only set in the constructor should be declared `immutable`',

--- a/src/issues/GAS/initializeDefaultValue.ts
+++ b/src/issues/GAS/initializeDefaultValue.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'initializeDefaultValue',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: "Don't initialize variables with default value",

--- a/src/issues/GAS/longRevertString.ts
+++ b/src/issues/GAS/longRevertString.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'longRevertString',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Reduce the size of error messages (Long revert Strings)',

--- a/src/issues/GAS/payableFunctions.ts
+++ b/src/issues/GAS/payableFunctions.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'payableFunctions',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Functions guaranteed to revert when called by normal users can be marked `payable`',

--- a/src/issues/GAS/postIncrement.ts
+++ b/src/issues/GAS/postIncrement.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'postIncrement',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: '`++i` costs less gas compared to `i++` or `i += 1` (same for `--i` vs `i--` or `i -= 1`)',

--- a/src/issues/GAS/privateForConstants.ts
+++ b/src/issues/GAS/privateForConstants.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'privateForConstants',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Using `private` rather than `public` for constants, saves gas',

--- a/src/issues/GAS/shiftInsteadOfDiv.ts
+++ b/src/issues/GAS/shiftInsteadOfDiv.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'shiftInsteadOfDiv',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use shift right/left instead of division/multiplication if possible',

--- a/src/issues/GAS/splitRequireStatement.ts
+++ b/src/issues/GAS/splitRequireStatement.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'splitRequireStatement',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Splitting require() statements that use && saves gas',

--- a/src/issues/GAS/superfluousEventField.ts
+++ b/src/issues/GAS/superfluousEventField.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'superfluousEventField',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Superfluous event fields',

--- a/src/issues/GAS/thisExternal.ts
+++ b/src/issues/GAS/thisExternal.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'thisExternal',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use of `this` instead of marking as `public` an `external` function',

--- a/src/issues/GAS/uintBoolBitMaps.ts
+++ b/src/issues/GAS/uintBoolBitMaps.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'uintBoolBitMaps',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: '`uint256` to `bool` `mapping`: Utilizing Bitmaps to dramatically save on Gas',

--- a/src/issues/GAS/uncheckedIncrements.ts
+++ b/src/issues/GAS/uncheckedIncrements.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'uncheckedIncrements',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Increments/decrements can be unchecked in for-loops',

--- a/src/issues/GAS/unsignedComparison.ts
+++ b/src/issues/GAS/unsignedComparison.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'unsignedComparison',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use != 0 instead of > 0 for unsigned integer comparison',

--- a/src/issues/GAS/uselessInternal.ts
+++ b/src/issues/GAS/uselessInternal.ts
@@ -4,6 +4,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, topLevelFiles } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'uselessInternal',
   regexOrAST: 'AST',
   type: IssueTypes.GAS,
   title: '`internal` functions not called by the contract should be removed',

--- a/src/issues/GAS/wethHardcode.ts
+++ b/src/issues/GAS/wethHardcode.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'wethHardcode',
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'WETH address definition can be use directly',

--- a/src/issues/H/comparisonOutsideCondition.ts
+++ b/src/issues/H/comparisonOutsideCondition.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'comparisonOutsideCondition',
   regexOrAST: 'Regex',
   type: IssueTypes.H,
   title: 'Incorrect comparison implementation',

--- a/src/issues/H/delegateCallInLoop.ts
+++ b/src/issues/H/delegateCallInLoop.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'delegateCallInLoop',
   regexOrAST: 'Regex',
   type: IssueTypes.H,
   title: 'Using `delegatecall` inside a loop',

--- a/src/issues/H/get_dy_underlyingFlashLoan.ts
+++ b/src/issues/H/get_dy_underlyingFlashLoan.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'getDyUnderlyingFlashLoan',
   regexOrAST: 'Regex',
   type: IssueTypes.H,
   title: '`get_dy_underlying()` is not a flash-loan-resistant price',

--- a/src/issues/H/msg.valueInLoop.ts
+++ b/src/issues/H/msg.valueInLoop.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, lineFromIndex } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'msgValueInLoop',
   regexOrAST: 'AST',
   type: IssueTypes.H,
   title: 'Using `msg.value` in a loop',

--- a/src/issues/H/wstETHPriceStEth.ts
+++ b/src/issues/H/wstETHPriceStEth.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'wstEthPriceStEth',
   regexOrAST: 'Regex',
   type: IssueTypes.H,
   title: "`wstETH`'s functions operate on units of stEth, not Eth",

--- a/src/issues/L/2stepowner.ts
+++ b/src/issues/L/2stepowner.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: '2stepowner',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Use a 2-step ownership transfer pattern',

--- a/src/issues/L/MultiplicationBeforeDivision.ts
+++ b/src/issues/L/MultiplicationBeforeDivision.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes } from '../../types';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'multiplicationBeforeDivision',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Precision Loss due to Division before Multiplication',

--- a/src/issues/L/NFTNoHandleHardForks.ts
+++ b/src/issues/L/NFTNoHandleHardForks.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC, lineFromIndex } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'nftNoHandleHardForks',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'NFT doesn\'t handle hard forks',

--- a/src/issues/L/SomeERC20TransferRevertsOn0.ts
+++ b/src/issues/L/SomeERC20TransferRevertsOn0.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'someERC20TransferRevertsOn0',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Some tokens may revert when zero value transfers are made',

--- a/src/issues/L/address0Check.ts
+++ b/src/issues/L/address0Check.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { getStorageVariable, instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'address0Check',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Missing checks for `address(0)` when assigning values to address state variables',

--- a/src/issues/L/avoidEcrecover.ts
+++ b/src/issues/L/avoidEcrecover.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'avoidEcrecover',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Use of `ecrecover` is susceptible to signature malleability',

--- a/src/issues/L/avoidEncodePacked.ts
+++ b/src/issues/L/avoidEncodePacked.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'avoidEncodePacked',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title:

--- a/src/issues/L/avoidTxOrigin.ts
+++ b/src/issues/L/avoidTxOrigin.ts
@@ -1,6 +1,7 @@
 import {IssueTypes} from "../../types";
 
 const issue = {
+    id: 'avoidTxOrigin',
     regexOrAST: 'Regex',
     type: IssueTypes.L,
     title: 'Use of `tx.origin` is unsafe in almost every context',

--- a/src/issues/L/calc_token_amountAlreadyHasSlippage.ts
+++ b/src/issues/L/calc_token_amountAlreadyHasSlippage.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'calcTokenAmountSlippage',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`calc_token_amount()` has slippage added on top of Curve\'s calculated slippage',

--- a/src/issues/L/decimalsNotERC20.ts
+++ b/src/issues/L/decimalsNotERC20.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'decimalsNotERC20',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`decimals()` is not a part of the ERC-20 standard',

--- a/src/issues/L/decimalsNotUint8.ts
+++ b/src/issues/L/decimalsNotUint8.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'decimalsNotUint8',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`decimals()` should be of type `uint8`',

--- a/src/issues/L/deprecatedApprove.ts
+++ b/src/issues/L/deprecatedApprove.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'deprecatedApprove',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Deprecated approve() function',

--- a/src/issues/L/deprecatedFunctions.ts
+++ b/src/issues/L/deprecatedFunctions.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'deprecatedFunctions',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Do not use deprecated library functions',

--- a/src/issues/L/deprecatedSafeApprove.ts
+++ b/src/issues/L/deprecatedSafeApprove.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'deprecatedSafeApprove',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`safeApprove()` is deprecated',

--- a/src/issues/L/deprecatedSetupRole.ts
+++ b/src/issues/L/deprecatedSetupRole.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'deprecatedSetupRole',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Deprecated _setupRole() function',

--- a/src/issues/L/disableInitImpl.ts
+++ b/src/issues/L/disableInitImpl.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'disableInitImpl',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Do not leave an implementation contract uninitialized',

--- a/src/issues/L/div0NotPrevented.ts
+++ b/src/issues/L/div0NotPrevented.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'div0NotPrevented',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Division by zero not prevented',

--- a/src/issues/L/domainSeparatorReplayAttack.ts
+++ b/src/issues/L/domainSeparatorReplayAttack.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'domainSeparatorReplayAttack',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`domainSeparator()` isn\'t protected against replay attacks in case of a future chain split ',

--- a/src/issues/L/duplicateImports.ts
+++ b/src/issues/L/duplicateImports.ts
@@ -5,6 +5,7 @@ import util from 'util';
 
 // regex: /(\{\})|(\{ \})/gi,
 const issue: ASTIssue = {
+  id: 'duplicateImports',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Duplicate import statements',

--- a/src/issues/L/emptyBody.ts
+++ b/src/issues/L/emptyBody.ts
@@ -5,6 +5,7 @@ import util from 'util';
 
 // regex: /(\{\})|(\{ \})/gi,
 const issue: ASTIssue = {
+  id: 'emptyBody',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Empty Function Body - Consider commenting why',

--- a/src/issues/L/emptyFallbackRequire.ts
+++ b/src/issues/L/emptyFallbackRequire.ts
@@ -5,6 +5,7 @@ import util from 'util';
 
 // regex: /(\{\})|(\{ \})/gi,
 const issue: ASTIssue = {
+  id: 'emptyFallbackRequire',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Empty `receive()/payable fallback()` function does not authenticate requests',

--- a/src/issues/L/extCallLoop.ts
+++ b/src/issues/L/extCallLoop.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { getStorageVariable, instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'extCallLoop',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'External calls in an un-bounded `for-`loop may result in a DOS',

--- a/src/issues/L/extCallRecipientGas.ts
+++ b/src/issues/L/extCallRecipientGas.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'extCallRecipientGas',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'External call recipient may consume all transaction gas',

--- a/src/issues/L/fallBackLackPayable.ts
+++ b/src/issues/L/fallBackLackPayable.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'fallBackLackPayable',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Fallback lacking `payable`',

--- a/src/issues/L/frontRunnableInitializer.ts
+++ b/src/issues/L/frontRunnableInitializer.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'frontRunnableInitializer',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Initializers could be front-run',

--- a/src/issues/L/includeTimestampAtDeadline.ts
+++ b/src/issues/L/includeTimestampAtDeadline.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'includeTimestampAtDeadline',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Signature use at deadlines should be allowed',

--- a/src/issues/L/lackSlippage.ts
+++ b/src/issues/L/lackSlippage.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'lackSlippage',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Lack of Slippage check',

--- a/src/issues/L/mathmaxInt.ts
+++ b/src/issues/L/mathmaxInt.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'mathmaxInt',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`Math.max(<x>,0)` used with `int` cast to `uint`',

--- a/src/issues/L/mintAndBurnAddress0.ts
+++ b/src/issues/L/mintAndBurnAddress0.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'mintAndBurnAddress0',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Prevent accidentally burning tokens',

--- a/src/issues/L/nftOwnershipHardfork.ts
+++ b/src/issues/L/nftOwnershipHardfork.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'nftOwnershipHardfork',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'NFT ownership doesn\'t support hard forks',

--- a/src/issues/L/ownerRenounceDuringPause.ts
+++ b/src/issues/L/ownerRenounceDuringPause.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'ownerRenounceDuringPause',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Owner can renounce while system is paused',

--- a/src/issues/L/possibleRounding.ts
+++ b/src/issues/L/possibleRounding.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'possibleRounding',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Possible rounding issue',

--- a/src/issues/L/pragmaExpDeprecated.ts
+++ b/src/issues/L/pragmaExpDeprecated.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'pragmaExpDeprecated',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`pragma experimental ABIEncoderV2` is deprecated',

--- a/src/issues/L/precisionLoss.ts
+++ b/src/issues/L/precisionLoss.ts
@@ -2,6 +2,7 @@ import { IssueTypes, RegexIssue } from '../../types';
 
 //@note there will be false positives
 const issue: RegexIssue = {
+  id: 'precisionLoss',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Loss of precision',

--- a/src/issues/L/push0Solc0820.ts
+++ b/src/issues/L/push0Solc0820.ts
@@ -3,6 +3,7 @@ import { findAll } from 'solidity-ast/utils';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'push0Solc0820',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Solidity version 0.8.20+ may not work on other chains due to `PUSH0`',

--- a/src/issues/L/safeTransferOwnership.ts
+++ b/src/issues/L/safeTransferOwnership.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'safeTransferOwnership',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Use `Ownable2Step.transferOwnership` instead of `Ownable.transferOwnership`',

--- a/src/issues/L/solc1314OptimizerBug.ts
+++ b/src/issues/L/solc1314OptimizerBug.ts
@@ -3,6 +3,7 @@ import { findAll } from 'solidity-ast/utils';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'solc1314OptimizerBug',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'File allows a version of solidity that is susceptible to an assembly optimizer bug',

--- a/src/issues/L/sweepingRescuing.ts
+++ b/src/issues/L/sweepingRescuing.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'sweepingRescuing',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Sweeping may break accounting if tokens with multiple addresses are used',

--- a/src/issues/L/symbolNotERC20.ts
+++ b/src/issues/L/symbolNotERC20.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'symbolNotERC20',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: '`symbol()` is not a part of the ERC-20 standard',

--- a/src/issues/L/unsafeCasting.ts
+++ b/src/issues/L/unsafeCasting.ts
@@ -5,6 +5,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'unsafeCasting',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title:

--- a/src/issues/L/unsafeERC20Operations.ts
+++ b/src/issues/L/unsafeERC20Operations.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'unsafeERC20Operations',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Unsafe ERC20 operation(s)',

--- a/src/issues/L/unsafeReturnBomb.ts
+++ b/src/issues/L/unsafeReturnBomb.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'unsafeReturnBomb',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Unsafe solidity low-level call can cause gas grief attack',

--- a/src/issues/L/unspecifiedPragma.ts
+++ b/src/issues/L/unspecifiedPragma.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'unspecifiedPragma',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Unspecific compiler version pragma',

--- a/src/issues/L/upgradeableMissingGap.ts
+++ b/src/issues/L/upgradeableMissingGap.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'upgradeableMissingGap',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title:

--- a/src/issues/L/upgradeableNotInit.ts
+++ b/src/issues/L/upgradeableNotInit.ts
@@ -2,6 +2,7 @@ import { IssueTypes, RegexIssue } from '../../types';
 
 //@audit-issue TODO - lots of false positives
 const issue: RegexIssue = {
+  id: 'upgradeableNotInit',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Upgradeable contract not initialized',

--- a/src/issues/L/useOfEcrecover.ts
+++ b/src/issues/L/useOfEcrecover.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'useOfEcrecover',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: "Use of ecrecover is susceptible to signature malleability",

--- a/src/issues/L/useOnlyInitializing.ts
+++ b/src/issues/L/useOnlyInitializing.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'useOnlyInitializing',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: 'Use `initializer` for public-facing functions only. Replace with `onlyInitializing` on internal functions.',

--- a/src/issues/L/year365.ts
+++ b/src/issues/L/year365.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'year365',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'A year is not always 365 days',

--- a/src/issues/M/FoTTokens.ts
+++ b/src/issues/M/FoTTokens.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'foTTokens',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Contracts are vulnerable to fee-on-transfer accounting-related issues',

--- a/src/issues/M/NFTRedefinesMint.ts
+++ b/src/issues/M/NFTRedefinesMint.ts
@@ -4,6 +4,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, topLevelFiles, getStorageVariable } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'nftRedefinesMint',
   regexOrAST: 'AST',
   type: IssueTypes.L,
   title: "NFT contract redefines `_mint()`/`_safeMint()`, but not both",

--- a/src/issues/M/approve0first.ts
+++ b/src/issues/M/approve0first.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'approve0first',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: "`approve()`/`safeApprove()` may revert if the current approval is not zero",

--- a/src/issues/M/avoidTx.origin.ts
+++ b/src/issues/M/avoidTx.origin.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'avoidTxOrigin',
   regexOrAST: 'Regex',
   type: IssueTypes.L,
   title: 'Use of `tx.origin` is unsafe in almost every context',

--- a/src/issues/M/blockNumberL2.ts
+++ b/src/issues/M/blockNumberL2.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'blockNumberL2',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title:

--- a/src/issues/M/centralizationRisk.ts
+++ b/src/issues/M/centralizationRisk.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'centralizationRisk',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title: 'Centralization Risk for trusted owners',

--- a/src/issues/M/deprecatedChainlinkFunction.ts
+++ b/src/issues/M/deprecatedChainlinkFunction.ts
@@ -1,6 +1,7 @@
 import {IssueTypes} from "../../types";
 
 const issue = {
+    id: 'deprecatedChainlinkFunction',
     regexOrAST: 'Regex',
     type: IssueTypes.M,
     title: 'Use of deprecated chainlink function: `latestAnswer()`',

--- a/src/issues/M/deprecatedTransfer.ts
+++ b/src/issues/M/deprecatedTransfer.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'deprecatedTransfer',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: '`call()` should be used instead of `transfer()` on an `address payable`',

--- a/src/issues/M/erc721safeMint.ts
+++ b/src/issues/M/erc721safeMint.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'erc721safeMint',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title: '`_safeMint()` should be used rather than `_mint()` wherever possible',

--- a/src/issues/M/erc721safeTransferFrom.ts
+++ b/src/issues/M/erc721safeTransferFrom.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'erc721safeTransferFrom',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title: 'Using `transferFrom` on ERC721 tokens',

--- a/src/issues/M/feeOver100.ts
+++ b/src/issues/M/feeOver100.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'feeOver100',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Fees can be set to be greater than 100%.',

--- a/src/issues/M/increaseAllowanceUSDT.ts
+++ b/src/issues/M/increaseAllowanceUSDT.ts
@@ -4,6 +4,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, topLevelFiles, getStorageVariable } from '../../utils';
 
 const issue: RegexIssue = {
+  id: 'increaseAllowanceUSDT',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title: "`increaseAllowance/decreaseAllowance` won't work on mainnet for USDT",

--- a/src/issues/M/keccakOnStructOrArray.ts
+++ b/src/issues/M/keccakOnStructOrArray.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'keccakOnStructOrArray',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Lack of EIP-712 compliance: using `keccak256()` directly on an array or struct variable',

--- a/src/issues/M/libraryPublicFunction.ts
+++ b/src/issues/M/libraryPublicFunction.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'libraryPublicFunction',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Library function isn\'t `internal` or `private`',

--- a/src/issues/M/soladySafeTransferLib.ts
+++ b/src/issues/M/soladySafeTransferLib.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'soladySafeTransferLib',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title:

--- a/src/issues/M/solmateSafeTransferLib.ts
+++ b/src/issues/M/solmateSafeTransferLib.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'solmateSafeTransferLib',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title:

--- a/src/issues/M/staleOracleData.ts
+++ b/src/issues/M/staleOracleData.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, lineFromIndex } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'staleOracleData',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: "Chainlink's `latestRoundData` might return stale or incorrect results",

--- a/src/issues/M/staleOracleDataL2Sequencer.ts
+++ b/src/issues/M/staleOracleDataL2Sequencer.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC, lineFromIndex } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'staleOracleDataL2Sequencer',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: "Missing checks for whether the L2 Sequencer is active",

--- a/src/issues/M/supportInterface.ts
+++ b/src/issues/M/supportInterface.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'supportInterface',
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title: 'Direct `supportsInterface()` calls may cause caller to revert',

--- a/src/issues/M/uncheckedERC20Transfer.ts
+++ b/src/issues/M/uncheckedERC20Transfer.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'uncheckedERC20Transfer',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Return values of `transfer()`/`transferFrom()` not checked',

--- a/src/issues/M/unsafeERC20Transfer.ts
+++ b/src/issues/M/unsafeERC20Transfer.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'unsafeERC20Transfer',
   regexOrAST: 'AST',
   type: IssueTypes.M,
   title: 'Unsafe use of `transfer()`/`transferFrom()` with `IERC20`',

--- a/src/issues/NC/abiEncodeCall.ts
+++ b/src/issues/NC/abiEncodeCall.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'abiEncodeCall',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title:

--- a/src/issues/NC/abicoderv2.ts
+++ b/src/issues/NC/abicoderv2.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'abicoderV2',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'abicoder v2 is enabled by default',

--- a/src/issues/NC/address0Check.ts
+++ b/src/issues/NC/address0Check.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { getStorageVariable, instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'address0Check',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Missing checks for `address(0)` when assigning values to address state variables',

--- a/src/issues/NC/arrayIndices.ts
+++ b/src/issues/NC/arrayIndices.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { getStorageVariable, instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'arrayIndices',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Array indices should be referenced via `enum`s rather than via numeric literals',

--- a/src/issues/NC/assertRequire.ts
+++ b/src/issues/NC/assertRequire.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'assertRequire',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`require()` should be used instead of `assert()`',

--- a/src/issues/NC/concat.ts
+++ b/src/issues/NC/concat.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'concat',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Use `string.concat()` or `bytes.concat()` instead of `abi.encodePacked`',

--- a/src/issues/NC/constantStyle.ts
+++ b/src/issues/NC/constantStyle.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'constantStyle',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Constants should be in CONSTANT_CASE',

--- a/src/issues/NC/constantsInsteadMagic.ts
+++ b/src/issues/NC/constantsInsteadMagic.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'constantsInsteadMagic',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`constant`s should be defined rather than using magic numbers',

--- a/src/issues/NC/controlStructureStyle.ts
+++ b/src/issues/NC/controlStructureStyle.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'controlStructureStyle',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Control structures do not follow the Solidity Style Guide',

--- a/src/issues/NC/criticalChange.ts
+++ b/src/issues/NC/criticalChange.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'criticalChange',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Critical Changes Should Use Two-step Procedure',

--- a/src/issues/NC/dangerWhileTrue.ts
+++ b/src/issues/NC/dangerWhileTrue.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'dangerWhileTrue',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Dangerous `while(true)` loop',

--- a/src/issues/NC/defaultVisibility.ts
+++ b/src/issues/NC/defaultVisibility.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'defaultVisibility',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Default Visibility for constants',

--- a/src/issues/NC/deleteLogs.ts
+++ b/src/issues/NC/deleteLogs.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'deleteLogs',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Delete rogue `console.log` imports',

--- a/src/issues/NC/disableRenounceOwnership.ts
+++ b/src/issues/NC/disableRenounceOwnership.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'disableRenounceOwnership',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Consider disabling `renounceOwnership()`',

--- a/src/issues/NC/draft-OZ.ts
+++ b/src/issues/NC/draft-OZ.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'draftOZ',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Draft Dependencies',

--- a/src/issues/NC/duplicateRequireRevert.ts
+++ b/src/issues/NC/duplicateRequireRevert.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'duplicateRequireRevert',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Duplicated `require()`/`revert()` Checks Should Be Refactored To A Modifier Or Function',

--- a/src/issues/NC/elseBlockOnReturn.ts
+++ b/src/issues/NC/elseBlockOnReturn.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'elseBlockOnReturn',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: '`else`-block not required',

--- a/src/issues/NC/errorneverUsed.ts
+++ b/src/issues/NC/errorneverUsed.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC, lineFromIndex } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'errorneverUsed',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Unused `error` definition',

--- a/src/issues/NC/eventNeverEmitted.ts
+++ b/src/issues/NC/eventNeverEmitted.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'eventNeverEmitted',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Event is never emitted',

--- a/src/issues/NC/eventNoArgs.ts
+++ b/src/issues/NC/eventNoArgs.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'eventNoArgs',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Events should use parameters to convey information',

--- a/src/issues/NC/eventNotProperlyIndexed.ts
+++ b/src/issues/NC/eventNotProperlyIndexed.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'eventNotProperlyIndexed',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Event missing indexed field',

--- a/src/issues/NC/eventOldNew.ts
+++ b/src/issues/NC/eventOldNew.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'eventOldNew',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Events that mark critical parameter changes should contain both the old and the new value',

--- a/src/issues/NC/functionOrdering.ts
+++ b/src/issues/NC/functionOrdering.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'functionOrdering',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Function ordering does not follow the Solidity style guide',

--- a/src/issues/NC/functionsTooLong.ts
+++ b/src/issues/NC/functionsTooLong.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'functionsTooLong',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Functions should not be longer than 50 lines',

--- a/src/issues/NC/implicitInt.ts
+++ b/src/issues/NC/implicitInt.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'implicitInt',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Change int to int256',

--- a/src/issues/NC/implicitUint.ts
+++ b/src/issues/NC/implicitUint.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'implicitUint',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Change uint to uint256',

--- a/src/issues/NC/interfaceInaming.ts
+++ b/src/issues/NC/interfaceInaming.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'interfaceInaming',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Interfaces should be indicated with an `I` prefix in the contract name',

--- a/src/issues/NC/interfaceOwnFile.ts
+++ b/src/issues/NC/interfaceOwnFile.ts
@@ -3,6 +3,7 @@ import { findAll } from 'solidity-ast/utils';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'interfaceOwnFile',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Interfaces should be defined in separate files from their usage',

--- a/src/issues/NC/lackReasonableBounds.ts
+++ b/src/issues/NC/lackReasonableBounds.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'lackReasonableBounds',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Lack of checks in setters',

--- a/src/issues/NC/linesTooLong.ts
+++ b/src/issues/NC/linesTooLong.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'linesTooLong',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Lines are too long',

--- a/src/issues/NC/mappingStyle.ts
+++ b/src/issues/NC/mappingStyle.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'mappingStyle',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`mapping` definitions do not follow the Solidity Style Guide',

--- a/src/issues/NC/maxUint.ts
+++ b/src/issues/NC/maxUint.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'maxUint',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`type(uint<n>).max` should be used instead of `uint<n>(-1)`',

--- a/src/issues/NC/maxUint256.ts
+++ b/src/issues/NC/maxUint256.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'maxUint256',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`type(uint256).max` should be used instead of `2 ** 256 - 1`',

--- a/src/issues/NC/missingEventSetters.ts
+++ b/src/issues/NC/missingEventSetters.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'missingEventSetters',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Missing Event for critical parameters change',

--- a/src/issues/NC/missingNatspec.ts
+++ b/src/issues/NC/missingNatspec.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'missingNatspec',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'NatSpec is completely non-existent on functions that should have them',

--- a/src/issues/NC/missingNatspecParam.ts
+++ b/src/issues/NC/missingNatspecParam.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'missingNatspecParam',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Incomplete NatSpec: `@param` is missing on actually documented functions',

--- a/src/issues/NC/missingNatspecReturn.ts
+++ b/src/issues/NC/missingNatspecReturn.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'missingNatspecReturn',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Incomplete NatSpec: `@return` is missing on actually documented functions',

--- a/src/issues/NC/missingSPDX.ts
+++ b/src/issues/NC/missingSPDX.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'missingSPDX',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'File\'s first line is not an SPDX Identifier',

--- a/src/issues/NC/modifierForMsgSender.ts
+++ b/src/issues/NC/modifierForMsgSender.ts
@@ -2,6 +2,7 @@ import { IssueTypes, RegexIssue } from '../../types';
 
 // Also catches the checks in modifiers and should be an AST detector
 const issue: RegexIssue = {
+  id: 'modifierForMsgSender',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Use a `modifier` instead of a `require/if` statement for a special `msg.sender` actor',

--- a/src/issues/NC/multipleConstantDeclaration.ts
+++ b/src/issues/NC/multipleConstantDeclaration.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'multipleConstantDeclaration',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Constant state variables defined more than once',

--- a/src/issues/NC/namedMappings.ts
+++ b/src/issues/NC/namedMappings.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'namedMappings',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Consider using named mappings',

--- a/src/issues/NC/noAddressHardcode.ts
+++ b/src/issues/NC/noAddressHardcode.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'noAddressHardcode',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: '`address`s shouldn\'t be hard-coded',

--- a/src/issues/NC/nonReentrantBeforeModifiers.ts
+++ b/src/issues/NC/nonReentrantBeforeModifiers.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'nonReentrantBeforeModifiers',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'The `nonReentrant` `modifier` should occur before all other modifiers',

--- a/src/issues/NC/numericTimeDays.ts
+++ b/src/issues/NC/numericTimeDays.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'numericTimeDays',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Numeric values having to do with time should use time units for readability',

--- a/src/issues/NC/onlyConstantsInUppercase.ts
+++ b/src/issues/NC/onlyConstantsInUppercase.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'onlyConstantsInUppercase',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Variable names that consist of all capital letters should be reserved for `constant`/`immutable` variables',

--- a/src/issues/NC/ownerCanRenounceWhilePaused.ts
+++ b/src/issues/NC/ownerCanRenounceWhilePaused.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'ownerCanRenounceWhilePaused',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Owner can renounce while system is paused',

--- a/src/issues/NC/redundantNamedReturn.ts
+++ b/src/issues/NC/redundantNamedReturn.ts
@@ -5,6 +5,7 @@ import { instanceFromSRC } from '../../utils';
 
 //@note trop fier de moi
 const issue: ASTIssue = {
+  id: 'redundantNamedReturn',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Adding a `return` statement when the function defines a named return variable, is redundant',

--- a/src/issues/NC/requireWithString.ts
+++ b/src/issues/NC/requireWithString.ts
@@ -3,6 +3,7 @@ import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../typ
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'requireWithString',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: '`require()` / `revert()` statements should have descriptive reason strings',

--- a/src/issues/NC/revertWithoutArgument.ts
+++ b/src/issues/NC/revertWithoutArgument.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'revertWithoutArgument',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: "Take advantage of Custom Error's return value property",

--- a/src/issues/NC/safeMath08.ts
+++ b/src/issues/NC/safeMath08.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'safeMath08',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Deprecated library used for Solidity `>= 0.8` : SafeMath',

--- a/src/issues/NC/scientificNotationExponent.ts
+++ b/src/issues/NC/scientificNotationExponent.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'scientificNotationExponent',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Use scientific notation (e.g. `1e18`) rather than exponentiation (e.g. `10**18`)',

--- a/src/issues/NC/scientificNotationZeros.ts
+++ b/src/issues/NC/scientificNotationZeros.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'scientificNotationZeros',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Use scientific notation for readability reasons for large multiples of ten',

--- a/src/issues/NC/sensitiveTerms.ts
+++ b/src/issues/NC/sensitiveTerms.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'sensitiveTerms',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Avoid the use of sensitive terms',

--- a/src/issues/NC/stringQuote.ts
+++ b/src/issues/NC/stringQuote.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'stringQuote',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Strings should use double quotes rather than single quotes',

--- a/src/issues/NC/style.ts
+++ b/src/issues/NC/style.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'style',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Function writing that does not comply with the Solidity Style Guide',

--- a/src/issues/NC/styleGuide.ts
+++ b/src/issues/NC/styleGuide.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'styleGuide',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: "Contract does not follow the Solidity style guide's suggested layout ordering",

--- a/src/issues/NC/todoLeftInTheCode.ts
+++ b/src/issues/NC/todoLeftInTheCode.ts
@@ -3,6 +3,7 @@ import { IssueTypes, RegexIssue } from '../../types';
 // TODO: This finding won't work until we add a flag to specify findings 
 // that either also search in commentsOr only search in comments
 const issue: RegexIssue = {
+  id: 'todoLeftInTheCode',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'TODO Left in the code',

--- a/src/issues/NC/unclearRequire.ts
+++ b/src/issues/NC/unclearRequire.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'unclearRequire',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Some require descriptions are not clear',

--- a/src/issues/NC/underscoreDecimals.ts
+++ b/src/issues/NC/underscoreDecimals.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'underscoreDecimals',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Use Underscores for Number Literals (add an underscore every 3 digits)',

--- a/src/issues/NC/underscoreInternal.ts
+++ b/src/issues/NC/underscoreInternal.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'underscoreInternal',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Internal and private variables and functions names should begin with an underscore',

--- a/src/issues/NC/unindexedEvent.ts
+++ b/src/issues/NC/unindexedEvent.ts
@@ -4,6 +4,7 @@ import util from 'util';
 import { instanceFromSRC } from '../../utils';
 
 const issue: ASTIssue = {
+  id: 'unindexedEvent',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: 'Event is missing `indexed` fields',

--- a/src/issues/NC/useConstants.ts
+++ b/src/issues/NC/useConstants.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'useConstants',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Constants should be defined rather than using magic numbers',

--- a/src/issues/NC/uselessPublic.ts
+++ b/src/issues/NC/uselessPublic.ts
@@ -4,6 +4,7 @@ import { instanceFromSRC } from '../../utils';
 import util from 'util';
 
 const issue: ASTIssue = {
+  id: 'uselessPublic',
   regexOrAST: 'AST',
   type: IssueTypes.NC,
   title: '`public` functions not called by the contract should be declared `external` instead',

--- a/src/issues/NC/uselessZeroInit.ts
+++ b/src/issues/NC/uselessZeroInit.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'uselessZeroInit',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'Variables need not be initialized to zero',

--- a/src/issues/NC/v2728check.ts
+++ b/src/issues/NC/v2728check.ts
@@ -1,6 +1,7 @@
 import { IssueTypes, RegexIssue } from '../../types';
 
 const issue: RegexIssue = {
+  id: 'v2728check',
   regexOrAST: 'Regex',
   type: IssueTypes.NC,
   title: 'No need to check that `v == 27` or `v == 28` with `ecrecover`',

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ const main = async (
   githubLink: string | null,
   out: string,
   severityToRun: IssueTypes[],
+  skipDetectors: string[],
   scope?: string,
   sarifOut?: string,
   listFiles?: boolean,
@@ -69,7 +70,7 @@ const main = async (
   for (const t of severityToRun) {
     let analyses: Analysis[] = analyze(
       files,
-      issues.filter(i => i.type === t),
+      issues.filter(i => i.type === t && !skipDetectors.includes(i.id.toLowerCase())),
       !!githubLink ? githubLink : undefined,
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import sarif from './sarif';
 import compileAndBuildAST from './compile';
 import issues from './issues';
 import markdown from './markdown';
-import { InputType, IssueTypes, Analysis, AnalysisResults, ReportTypes } from './types';
+import { InputType, IssueTypes, Analysis, AnalysisResults, ReportTypes, Issue } from './types';
 import { recursiveExploration } from './utils';
 
 /*   .---. ,--.  ,--  / ,---.   ,--.   ,--.'  ,-. .----. ,------.,------, 
@@ -30,9 +30,10 @@ const main = async (
   scopeFile: string | null,
   githubLink: string | null,
   out: string,
+  severityToRun: IssueTypes[],
   scope?: string,
   sarifOut?: string,
-  listFiles?: boolean
+  listFiles?: boolean,
 ) => {
   let fileNames: string[] = [];
 
@@ -65,8 +66,7 @@ const main = async (
 
   let analysisResultsObj: AnalysisResults = {};
 
-  // todo: parameterize which issue types to run
-  for (const t of Object.values(IssueTypes)) {
+  for (const t of severityToRun) {
     let analyses: Analysis[] = analyze(
       files,
       issues.filter(i => i.type === t),

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type Issue = RegexIssue | ASTIssue;
 
 // Type to follow to add an issue detected by a regex
 export type RegexIssue = {
+  id: string;
   type: IssueTypes;
   title: string;
   regex: RegExp;
@@ -40,6 +41,7 @@ export type RegexIssue = {
 
 // Type to follow to add an issue detected by AST analysis
 export type ASTIssue = {
+  id: string;
   type: IssueTypes;
   title: string;
   impact?: string;


### PR DESCRIPTION
Adds feature for skipping detectors. Can filter detectors by severity level, or directly by detector ID.

To filter by severity, pass one or more of these options: `--skip-info --skip-gas --skip-low --skip-medium --skip-high`

To filter by ID name, pass this option and follow it with the Issue IDs that you'd like to skip: `--skip msgvalueinloop avoidtxorigin`.

These can be used in tandem, ie: `yarn analyze . --skip-gas --skip-info --skip msgvalueinloop stakeoracledata delegatecallinloop`

Issue IDs are not case sensitive for ease of use.
